### PR TITLE
Dev/bind9 hidden primary 0.2.0

### DIFF
--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,4 @@
+---
+rules:
+  comments:
+    min-spaces-from-content: 1 # Changed this to stop a mess between linters from Prettier (vscode) to yamllint - https://github.com/prettier/prettier/pull/10926 / https://github.com/redhat-developer/vscode-yaml/issues/433#issuecomment-2276330837

--- a/charts/bind9-hidden-primary/Chart.yaml
+++ b/charts/bind9-hidden-primary/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/bind9-hidden-primary/README.md
+++ b/charts/bind9-hidden-primary/README.md
@@ -1,6 +1,6 @@
 # bind9-hidden-primary
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 9.21](https://img.shields.io/badge/AppVersion-9.21-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 9.21](https://img.shields.io/badge/AppVersion-9.21-informational?style=flat-square)
 
 A Helm chart for bind9 to use as hidden primary, based on the offical Docker Image by InternetSystemsConsortium (ISC)
 
@@ -307,6 +307,48 @@ Alternatively, you could provide the values which you want to override at the CL
 </pre>
 </td>
 			<td>Specify default resources for the</td>
+		</tr>
+		<tr>
+			<td>runtimeClass</td>
+			<td>object</td>
+			<td><pre lang="json">
+{
+  "jobs": "",
+  "pods": ""
+}
+</pre>
+</td>
+			<td>Set a RuntimeClass to execute the containers with a custom runtime configuration. Register a runtimeClass within your cluster beforehand.
+
+<details>
+<summary>Motivation (Expand)</summary>
+
+> The container runtime configuration is used to run a Pod's containers. . . .
+> For example, if part of your workload deserves a high level of information security assurance, you might choose to schedule those Pods so that they run in a container runtime that uses hardware virtualization.
+> You'd then benefit from the extra isolation of the alternative runtime, at the expense of some additional overhead. . . .
+
+<i>Source and more informations: https://kubernetes.io/docs/concepts/containers/runtime-class/ </i>
+
+</details>
+</td>
+		</tr>
+		<tr>
+			<td>runtimeClass.jobs</td>
+			<td>string/runtimeClassName</td>
+			<td><pre lang="json">
+""
+</pre>
+</td>
+			<td>Sets the runtimeClass for the pods for the job execution. Takes the runtimeClass name, or "" (default).</td>
+		</tr>
+		<tr>
+			<td>runtimeClass.pods</td>
+			<td>string/runtimeClassName</td>
+			<td><pre lang="json">
+""
+</pre>
+</td>
+			<td>Sets the runtimeClass for the DaemonSet / ReplicaSet pods. Takes the runtimeClass name, or "" (default).</td>
 		</tr>
 		<tr>
 			<td>securityContext</td>

--- a/charts/bind9-hidden-primary/README.md
+++ b/charts/bind9-hidden-primary/README.md
@@ -221,7 +221,7 @@ Alternatively, you could provide the values which you want to override at the CL
 		</tr>
 		<tr>
 			<td>persistence</td>
-			<td>CHANGE REQUIRED</td>
+			<td>object</td>
 			<td><pre lang="json">
 {
   "accessModes": [
@@ -268,12 +268,12 @@ Alternatively, you could provide the values which you want to override at the CL
 		</tr>
 		<tr>
 			<td>providerPrimaryIpList</td>
-			<td>CHANGE REQUIRED</td>
+			<td>string</td>
 			<td><pre lang="json">
 "127.0.0.1"
 </pre>
 </td>
-			<td>List of upstream dns servers that are allowed to query the hidden primary and getting notified (Separator: ";") Provide your providers upstream IP and/or IPs.</td>
+			<td>List of upstream dns servers that are allowed to query the hidden primary (AXFR requests) and getting notified (Separator: ";") Provide your providers upstream IP and/or IPs.</td>
 		</tr>
 		<tr>
 			<td>readinessProbe</td>
@@ -427,7 +427,7 @@ Alternatively, you could provide the values which you want to override at the CL
 		</tr>
 		<tr>
 			<td>zone</td>
-			<td>CHANGE REQUIRED</td>
+			<td>object</td>
 			<td><pre lang="json">
 {
   "name": "myzone.sample-chart.example.com",
@@ -444,7 +444,25 @@ Alternatively, you could provide the values which you want to override at the CL
 }
 </pre>
 </td>
-			<td>Zone details zone:   name: Name of the zone that this bind deployment is authorative hidden primary  soa:    nsHostname: nameserver hostname for soa record... just use whatever you like, it does not need to be resolvable.    hostmasterMail: The mail that you like to publish withn the soa record. replace the @-sign by a dot, like: hostmaster@example.com -> hostmaster.example.com   spfTxtRecordValue: We set the SPF record to disallow all servers sending mails with this domain. You could overwirte it as you wish.   providerPrimaryNameservers: Provide a list of nameservers that are resposible for the zone. These are typically the providers primary nameservers.     - ns1.provider.tld     - ns2.provider.tld</td>
+			<td>Zone details Provide your zone details to configure the nameserver to match our needs.
+
+<details>
+<summary> Object param description (Expand)</summary>
+
+```
+zone:
+  name: Name of the zone that this bind deployment is authorative hidden primary
+  soa:
+    nsHostname: nameserver hostname for soa record... just use whatever you like, it does not need to be resolvable.
+    hostmasterMail: The mail that you like to publish withn the soa record. replace the @-sign by a dot, like: hostmaster@example.com -> hostmaster.example.com
+  spfTxtRecordValue: We set the SPF record to disallow all servers sending mails with this domain. You could overwirte it as you wish.
+  providerPrimaryNameservers: Provide a list of nameservers that are resposible for the zone. These are typically the providers primary nameservers.
+    - ns1.provider.tld
+    - ns2.provider.tld
+```
+
+</details>
+</td>
 		</tr>
 	</tbody>
 </table>

--- a/charts/bind9-hidden-primary/README.md
+++ b/charts/bind9-hidden-primary/README.md
@@ -1,3 +1,5 @@
+
+
 # bind9-hidden-primary
 
 ![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 9.21](https://img.shields.io/badge/AppVersion-9.21-informational?style=flat-square)
@@ -77,7 +79,7 @@ Alternatively, you could provide the values which you want to override at the CL
 
 ## Values
 
-<table>
+<table height="400px" >
 	<thead>
 		<th>Key</th>
 		<th>Type</th>
@@ -86,18 +88,27 @@ Alternatively, you could provide the values which you want to override at the CL
 	</thead>
 	<tbody>
 		<tr>
-			<td>affinity</td>
-			<td>object</td>
-			<td><pre lang="json">
+			<td id="affinity"><a href="./values.yaml#L231">affinity</a></td>
+			<td>
+object
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
 {}
 </pre>
-</td>
+</div>
+			</td>
 			<td></td>
 		</tr>
 		<tr>
-			<td>autoscaling</td>
-			<td>object</td>
-			<td><pre lang="json">
+			<td id="autoscaling"><a href="./values.yaml#L207">autoscaling</a></td>
+			<td>
+object
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
 {
   "enabled": false,
   "maxReplicas": 100,
@@ -105,25 +116,35 @@ Alternatively, you could provide the values which you want to override at the CL
   "targetCPUUtilizationPercentage": 80
 }
 </pre>
-</td>
+</div>
+			</td>
 			<td>This section is for setting up autoscaling more information can be found here: https://kubernetes.io/docs/concepts/workloads/autoscaling/</td>
 		</tr>
 		<tr>
-			<td>env</td>
-			<td>object</td>
-			<td><pre lang="json">
+			<td id="env"><a href="./values.yaml#L112">env</a></td>
+			<td>
+object
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
 {
   "tsigHmacFunc": "HMAC-SHA512",
   "tsigKeyname": "rndc-allow-transfer-tsigkey"
 }
 </pre>
-</td>
+</div>
+			</td>
 			<td>This configures the TSIG Key HMAC algo and Key Name which will be used within the configuration of bind9. Usually, you won't need to change these defaults. General details about the TSIG implementation could be found at: https://www.isc.org/docs/2021-bind-mgmt-05-webinar.pdf</td>
 		</tr>
 		<tr>
-			<td>existingConfigMap</td>
-			<td>object</td>
-			<td><pre lang="json">
+			<td id="existingConfigMap"><a href="./values.yaml#L169">existingConfigMap</a></td>
+			<td>
+object
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
 {
   "includes": "",
   "named": "",
@@ -131,65 +152,95 @@ Alternatively, you could provide the values which you want to override at the CL
   "zonedbs": ""
 }
 </pre>
-</td>
+</div>
+			</td>
 			<td>Provide your own includes.d/, named.conf and/or entrypoint configMap to override chart-included configurations.</td>
 		</tr>
 		<tr>
-			<td>fullnameOverride</td>
-			<td>string</td>
-			<td><pre lang="json">
+			<td id="fullnameOverride"><a href="./values.yaml#L49">fullnameOverride</a></td>
+			<td>
+string
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
 ""
 </pre>
-</td>
+</div>
+			</td>
 			<td></td>
 		</tr>
 		<tr>
-			<td>image</td>
-			<td>object</td>
-			<td><pre lang="json">
+			<td id="image"><a href="./values.yaml#L33">image</a></td>
+			<td>
+object
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
 {
   "pullPolicy": "IfNotPresent",
   "repository": "internetsystemsconsortium/bind9",
   "tag": ""
 }
 </pre>
-</td>
+</div>
+			</td>
 			<td>This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/ Override the image tag, whose default is the chart appVersion.</td>
 		</tr>
 		<tr>
-			<td>imagePullSecrets</td>
-			<td>list</td>
-			<td><pre lang="json">
+			<td id="imagePullSecrets"><a href="./values.yaml#L45">imagePullSecrets</a></td>
+			<td>
+list
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
 []
 </pre>
-</td>
+</div>
+			</td>
 			<td>This is for the secrets for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/</td>
 		</tr>
 		<tr>
-			<td>jobImage</td>
-			<td>object</td>
-			<td><pre lang="json">
+			<td id="jobImage"><a href="./values.yaml#L40">jobImage</a></td>
+			<td>
+object
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
 {
   "repository": "ghcr.io/codeadminde/bind9-kubectl",
   "tag": "latest"
 }
 </pre>
-</td>
+</div>
+			</td>
 			<td>This sets the job container image to use. The image needs kubectl and bind9 already present in order to fullfill it's job and to be used with a restricted namespace policy.</td>
 		</tr>
 		<tr>
-			<td>kind</td>
-			<td>string</td>
-			<td><pre lang="json">
+			<td id="kind"><a href="./values.yaml#L8">kind</a></td>
+			<td>
+string
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
 "DaemonSet"
 </pre>
-</td>
+</div>
+			</td>
 			<td>This will set the kind of deployment Use "Deployment" to deploy as ReplicaSet or use DaemonSet to deploy as DaemonSet.</td>
 		</tr>
 		<tr>
-			<td>livenessProbe</td>
-			<td>object</td>
-			<td><pre lang="json">
+			<td id="livenessProbe"><a href="./values.yaml#L191">livenessProbe</a></td>
+			<td>
+object
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
 {
   "initialDelaySeconds": 5,
   "periodSeconds": 10,
@@ -198,31 +249,46 @@ Alternatively, you could provide the values which you want to override at the CL
   }
 }
 </pre>
-</td>
+</div>
+			</td>
 			<td>This is to setup the liveness probe. By default, we're using the tcpSocket to provide the liveness state. More information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/</td>
 		</tr>
 		<tr>
-			<td>nameOverride</td>
-			<td>string</td>
-			<td><pre lang="json">
+			<td id="nameOverride"><a href="./values.yaml#L48">nameOverride</a></td>
+			<td>
+string
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
 ""
 </pre>
-</td>
+</div>
+			</td>
 			<td>This is to override the chart name.</td>
 		</tr>
 		<tr>
-			<td>nodeSelector</td>
-			<td>object</td>
-			<td><pre lang="json">
+			<td id="nodeSelector"><a href="./values.yaml#L227">nodeSelector</a></td>
+			<td>
+object
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
 {}
 </pre>
-</td>
+</div>
+			</td>
 			<td></td>
 		</tr>
 		<tr>
-			<td>persistence</td>
-			<td>object</td>
-			<td><pre lang="json">
+			<td id="persistence"><a href="./values.yaml#L156">persistence</a></td>
+			<td>
+object
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
 {
   "accessModes": [
     "ReadWriteMany"
@@ -234,51 +300,76 @@ Alternatively, you could provide the values which you want to override at the CL
   "storageClass": "longhorn"
 }
 </pre>
-</td>
+</div>
+			</td>
 			<td>This configures the persistens of your release. The bind9 service uses persistent storage to save it's current zone database and to ensure all running containers does share the same details. See values.yaml for a detailed sample.</td>
 		</tr>
 		<tr>
-			<td>podAnnotations</td>
-			<td>object</td>
-			<td><pre lang="json">
+			<td id="podAnnotations"><a href="./values.yaml#L65">podAnnotations</a></td>
+			<td>
+object
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
 {}
 </pre>
-</td>
+</div>
+			</td>
 			<td>This is for setting Kubernetes Annotations to a Pod. For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/</td>
 		</tr>
 		<tr>
-			<td>podLabels</td>
-			<td>object</td>
-			<td><pre lang="json">
+			<td id="podLabels"><a href="./values.yaml#L68">podLabels</a></td>
+			<td>
+object
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
 {}
 </pre>
-</td>
+</div>
+			</td>
 			<td>This is for setting Kubernetes Labels to a Pod. For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/</td>
 		</tr>
 		<tr>
-			<td>podSecurityContext</td>
-			<td>object</td>
-			<td><pre lang="json">
+			<td id="podSecurityContext"><a href="./values.yaml#L72">podSecurityContext</a></td>
+			<td>
+object
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
 {
   "fsGroup": 1000
 }
 </pre>
-</td>
+</div>
+			</td>
 			<td>This is for the pod-level security attributes and common container settings. More information: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/</td>
 		</tr>
 		<tr>
-			<td>providerPrimaryIpList</td>
-			<td>string</td>
-			<td><pre lang="json">
+			<td id="providerPrimaryIpList"><a href="./values.yaml#L118">providerPrimaryIpList</a></td>
+			<td>
+string
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
 "127.0.0.1"
 </pre>
-</td>
+</div>
+			</td>
 			<td>List of upstream dns servers that are allowed to query the hidden primary (AXFR requests) and getting notified (Separator: ";") Provide your providers upstream IP and/or IPs.</td>
 		</tr>
 		<tr>
-			<td>readinessProbe</td>
-			<td>object</td>
-			<td><pre lang="json">
+			<td id="readinessProbe"><a href="./values.yaml#L200">readinessProbe</a></td>
+			<td>
+object
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
 {
   "initialDelaySeconds": 5,
   "periodSeconds": 10,
@@ -287,37 +378,53 @@ Alternatively, you could provide the values which you want to override at the CL
   }
 }
 </pre>
-</td>
+</div>
+			</td>
 			<td>This is to setup the readiness probe. By default, we're using the tcpSocket to provide the readiness state. More information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/</td>
 		</tr>
 		<tr>
-			<td>replicaCount</td>
-			<td>int</td>
-			<td><pre lang="json">
+			<td id="replicaCount"><a href="./values.yaml#L12">replicaCount</a></td>
+			<td>
+int
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
 1
 </pre>
-</td>
+</div>
+			</td>
 			<td>This will set the replicaset count more information can be found here: https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/ (Only used when kind: Deployment)</td>
 		</tr>
 		<tr>
-			<td>resources</td>
-			<td>object</td>
-			<td><pre lang="json">
+			<td id="resources"><a href="./values.yaml#L176">resources</a></td>
+			<td>
+object
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
 {}
 </pre>
-</td>
+</div>
+			</td>
 			<td>Specify default resources for the</td>
 		</tr>
 		<tr>
-			<td>runtimeClass</td>
-			<td>object</td>
-			<td><pre lang="json">
+			<td id="runtimeClass"><a href="./values.yaml#L104">runtimeClass</a></td>
+			<td>
+object
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
 {
   "jobs": "",
   "pods": ""
 }
 </pre>
-</td>
+</div>
+			</td>
 			<td>Set a RuntimeClass to execute the containers with a custom runtime configuration. Register a runtimeClass within your cluster beforehand.
 
 <details>
@@ -333,27 +440,41 @@ Alternatively, you could provide the values which you want to override at the CL
 </td>
 		</tr>
 		<tr>
-			<td>runtimeClass.jobs</td>
-			<td>string/runtimeClassName</td>
-			<td><pre lang="json">
+			<td id="runtimeClass--jobs"><a href="./values.yaml#L108">runtimeClass.jobs</a></td>
+			<td>
+<a href="#stringruntimeclassname" title="Click to get details">string/runtimeClassName</a>
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
 ""
 </pre>
-</td>
+</div>
+			</td>
 			<td>Sets the runtimeClass for the pods for the job execution. Takes the runtimeClass name, or "" (default).</td>
 		</tr>
 		<tr>
-			<td>runtimeClass.pods</td>
-			<td>string/runtimeClassName</td>
-			<td><pre lang="json">
+			<td id="runtimeClass--pods"><a href="./values.yaml#L106">runtimeClass.pods</a></td>
+			<td>
+<a href="#stringruntimeclassname" title="Click to get details">string/runtimeClassName</a>
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
 ""
 </pre>
-</td>
+</div>
+			</td>
 			<td>Sets the runtimeClass for the DaemonSet / ReplicaSet pods. Takes the runtimeClass name, or "" (default).</td>
 		</tr>
 		<tr>
-			<td>securityContext</td>
-			<td>object</td>
-			<td><pre lang="json">
+			<td id="securityContext"><a href="./values.yaml#L78">securityContext</a></td>
+			<td>
+object
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
 {
   "allowPrivilegeEscalation": false,
   "capabilities": {
@@ -369,53 +490,78 @@ Alternatively, you could provide the values which you want to override at the CL
   }
 }
 </pre>
-</td>
+</div>
+			</td>
 			<td>This is for the scurityContext at container level. Note that container settings do not affect the Pod's Volumes. More information: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container</td>
 		</tr>
 		<tr>
-			<td>service</td>
-			<td>object</td>
-			<td><pre lang="json">
+			<td id="service"><a href="./values.yaml#L15">service</a></td>
+			<td>
+object
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
 {
   "externalTrafficPolicy": "Local",
   "port": 5353,
   "type": "LoadBalancer"
 }
 </pre>
-</td>
+</div>
+			</td>
 			<td>This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/</td>
 		</tr>
 		<tr>
-			<td>service.externalTrafficPolicy</td>
-			<td>string</td>
-			<td><pre lang="json">
+			<td id="service--externalTrafficPolicy"><a href="./values.yaml#L19">service.externalTrafficPolicy</a></td>
+			<td>
+string
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
 "Local"
 </pre>
-</td>
+</div>
+			</td>
 			<td>Set the externalTrafficPolicy to Local or Cluster. I recommmend to use Local in combination with kind: DaemonSet to get the real client-ip (as long as you won't have any other measures in place to get the real client-ip)</td>
 		</tr>
 		<tr>
-			<td>service.port</td>
-			<td>int</td>
-			<td><pre lang="json">
+			<td id="service--port"><a href="./values.yaml#L21">service.port</a></td>
+			<td>
+int
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
 5353
 </pre>
-</td>
+</div>
+			</td>
 			<td>This sets the ports more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports</td>
 		</tr>
 		<tr>
-			<td>service.type</td>
-			<td>string</td>
-			<td><pre lang="json">
+			<td id="service--type"><a href="./values.yaml#L17">service.type</a></td>
+			<td>
+string
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
 "LoadBalancer"
 </pre>
-</td>
+</div>
+			</td>
 			<td>This sets the service type more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types</td>
 		</tr>
 		<tr>
-			<td>serviceAccount</td>
-			<td>object</td>
-			<td><pre lang="json">
+			<td id="serviceAccount"><a href="./values.yaml#L52">serviceAccount</a></td>
+			<td>
+object
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
 {
   "annotations": {},
   "automount": true,
@@ -423,13 +569,18 @@ Alternatively, you could provide the values which you want to override at the CL
   "name": ""
 }
 </pre>
-</td>
+</div>
+			</td>
 			<td>This section builds out the service account more information can be found here: https://kubernetes.io/docs/concepts/security/service-accounts/</td>
 		</tr>
 		<tr>
-			<td>statisticsChannels</td>
-			<td>object</td>
-			<td><pre lang="json">
+			<td id="statisticsChannels"><a href="./values.yaml#L25">statisticsChannels</a></td>
+			<td>
+object
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
 {
   "enabled": false,
   "externalTrafficPolicy": "Local",
@@ -437,40 +588,60 @@ Alternatively, you could provide the values which you want to override at the CL
   "type": "ClusterIP"
 }
 </pre>
-</td>
+</div>
+			</td>
 			<td>The statistics channel provides a XML and JSON (/json) HTTP endpoint to monitor bind. It is not protected. Use a reverse-proxy with basic-auth and ssl, if you want to expose it externally.</td>
 		</tr>
 		<tr>
-			<td>tolerations</td>
-			<td>list</td>
-			<td><pre lang="json">
+			<td id="tolerations"><a href="./values.yaml#L229">tolerations</a></td>
+			<td>
+list
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
 []
 </pre>
-</td>
+</div>
+			</td>
 			<td></td>
 		</tr>
 		<tr>
-			<td>volumeMounts</td>
-			<td>list</td>
-			<td><pre lang="json">
+			<td id="volumeMounts"><a href="./values.yaml#L222">volumeMounts</a></td>
+			<td>
+list
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
 []
 </pre>
-</td>
+</div>
+			</td>
 			<td>Additional volumeMounts on the output Deployment definition.</td>
 		</tr>
 		<tr>
-			<td>volumes</td>
-			<td>list</td>
-			<td><pre lang="json">
+			<td id="volumes"><a href="./values.yaml#L215">volumes</a></td>
+			<td>
+list
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
 []
 </pre>
-</td>
+</div>
+			</td>
 			<td>Additional volumes on the output Deployment definition.</td>
 		</tr>
 		<tr>
-			<td>zone</td>
-			<td>object</td>
-			<td><pre lang="json">
+			<td id="zone"><a href="./values.yaml#L141">zone</a></td>
+			<td>
+object
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
 {
   "name": "myzone.sample-chart.example.com",
   "providerPrimaryNameservers": [
@@ -485,7 +656,8 @@ Alternatively, you could provide the values which you want to override at the CL
   "spfTxtRecordValue": "v=spf1 -all"
 }
 </pre>
-</td>
+</div>
+			</td>
 			<td>Zone details Provide your zone details to configure the nameserver to match our needs.
 
 <details>
@@ -508,6 +680,25 @@ zone:
 		</tr>
 	</tbody>
 </table>
+
+## Value type details
+
+The chart uses some value types for which I would like to add a further explanation / recommendation:
+
+### string/runtimeClassName
+
+Provide a valid name of a runtimeClass within your cluster.
+
+If you want to get the current available runtimeClasses within your cluster, exec:
+
+```
+kubectl get -A runtimeClasses
+```
+
+_**Personal recommendation**: A runtime that I believe is worth trying is the Kata Container Runtime.
+Take a look at xxx to get an overview about it.
+Also take a look at the HowTo-Section within the kata-container GitHub Repository,
+e.g. to learn [how to create a runtime class](https://github.com/kata-containers/kata-containers/blob/main/docs/how-to/run-kata-with-k8s.md#create-runtime-class-for-kata-containers)_
 
 ## Feedback & Security
 

--- a/charts/bind9-hidden-primary/templates/deployment.yaml
+++ b/charts/bind9-hidden-primary/templates/deployment.yaml
@@ -37,6 +37,9 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
+          {{- if .Values.runtimeClass.pods }}
+          runtimeClass: {{ .Values.runtimeClass.pods }}
+          {{- end }}
           {{- with .Values.securityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}

--- a/charts/bind9-hidden-primary/templates/job.yaml
+++ b/charts/bind9-hidden-primary/templates/job.yaml
@@ -20,6 +20,9 @@ spec:
       {{- end }}
       containers:
       - name: {{ .Chart.Name }}-tsigkey-patch-job
+        {{- if .Values.runtimeClass.jobs }}
+        runtimeClass: {{ .Values.runtimeClass.jobs }}
+        {{- end }}
         {{- with .Values.securityContext }}
         securityContext:
           {{- toYaml . | nindent 12 }}

--- a/charts/bind9-hidden-primary/values.yaml
+++ b/charts/bind9-hidden-primary/values.yaml
@@ -86,6 +86,27 @@ securityContext:
   seccompProfile:
     type: RuntimeDefault
 
+# -- Set a RuntimeClass to execute the containers with a custom runtime configuration.
+# Register a runtimeClass within your cluster beforehand.
+# @raw
+#
+# <details>
+# <summary>Motivation (Expand)</summary>
+#
+# > The container runtime configuration is used to run a Pod's containers. . . .
+# > For example, if part of your workload deserves a high level of information security assurance, you might choose to schedule those Pods so that they run in a container runtime that uses hardware virtualization.
+# > You'd then benefit from the extra isolation of the alternative runtime, at the expense of some additional overhead. . . .
+#
+# <i>Source and more informations: https://kubernetes.io/docs/concepts/containers/runtime-class/ </i>
+#
+# </details>
+#
+runtimeClass:
+  # -- (string/runtimeClassName) Sets the runtimeClass for the DaemonSet / ReplicaSet pods. Takes the runtimeClass name, or "" (default).
+  pods: ""
+  # -- (string/runtimeClassName) Sets the runtimeClass for the pods for the job execution. Takes the runtimeClass name, or "" (default).
+  jobs: ""
+
 # -- This configures the TSIG Key HMAC algo and Key Name which will be used within the configuration of bind9. Usually, you won't need to change these defaults.
 # General details about the TSIG implementation could be found at: https://www.isc.org/docs/2021-bind-mgmt-05-webinar.pdf
 env:

--- a/charts/bind9-hidden-primary/values.yaml
+++ b/charts/bind9-hidden-primary/values.yaml
@@ -92,20 +92,31 @@ env:
   tsigHmacFunc: HMAC-SHA512
   tsigKeyname: rndc-allow-transfer-tsigkey
 
-# -- (CHANGE REQUIRED) List of upstream dns servers that are allowed to query the hidden primary and getting notified (Separator: ";")
+# -- List of upstream dns servers that are allowed to query the hidden primary (AXFR requests) and getting notified (Separator: ";")
 # Provide your providers upstream IP and/or IPs.
 providerPrimaryIpList: "127.0.0.1"
 
-# -- (CHANGE REQUIRED) Zone details
+# -- Zone details
+# Provide your zone details to configure the nameserver to match our needs.
+# @raw
+#
+# <details>
+# <summary> Object param description (Expand)</summary>
+#
+# ```
 # zone:
 #   name: Name of the zone that this bind deployment is authorative hidden primary
-#  soa:
-#    nsHostname: nameserver hostname for soa record... just use whatever you like, it does not need to be resolvable.
-#    hostmasterMail: The mail that you like to publish withn the soa record. replace the @-sign by a dot, like: hostmaster@example.com -> hostmaster.example.com
+#   soa:
+#     nsHostname: nameserver hostname for soa record... just use whatever you like, it does not need to be resolvable.
+#     hostmasterMail: The mail that you like to publish withn the soa record. replace the @-sign by a dot, like: hostmaster@example.com -> hostmaster.example.com
 #   spfTxtRecordValue: We set the SPF record to disallow all servers sending mails with this domain. You could overwirte it as you wish.
 #   providerPrimaryNameservers: Provide a list of nameservers that are resposible for the zone. These are typically the providers primary nameservers.
 #     - ns1.provider.tld
 #     - ns2.provider.tld
+# ```
+#
+# </details>
+#
 zone:
   name: myzone.sample-chart.example.com # <== Provide your zone.
   soa:
@@ -117,7 +128,7 @@ zone:
     - b.sample-chart.example.com
     - c.sample-chart.example.com
 
-# -- (CHANGE REQUIRED) This configures the persistens of your release.
+# -- This configures the persistens of your release.
 # The bind9 service uses persistent storage to save it's current zone database
 # and to ensure all running containers does share the same details.
 # See values.yaml for a detailed sample.


### PR DESCRIPTION
* Added: Allow value-based runtimeClass assignment for pods within the ReplicaSet / DaemonSet & for pods within jobs.
* Change: Updated comments / Readme

Note: These changes does not break running configurations, because the runtimeClass configuration won't be assigned by default. You need to explicitly enable this by overriding the corresponding values within your release configuration.